### PR TITLE
Fixed one of the whyjoin variables

### DIFF
--- a/src/content/Home/index.js
+++ b/src/content/Home/index.js
@@ -221,7 +221,7 @@ const WhyJoin = [
   {
     key: 3,
     title: "home.whyJoin.classroomTitle",
-    desc: "home.whyJoin.classroomTitle",
+    desc: "home.whyJoin.classroom",
     imgsrc: classroom
   },
   {


### PR DESCRIPTION
One of the "whyJoin" variables had the title instead of the description