### PR TITLE
Fix: Prevents build error caused by an undefined variable.

### DIFF
--- a/src/content/ContactUs/index.js
+++ b/src/content/ContactUs/index.js
@@ -55,7 +55,7 @@ const ContactUs = () => {
           <br /> We're excited to hear from you!
         </p>
         <p>
-          <br /> <Text style={{fontWeight: "bold"}}> Connect With Us!</Text> <br /> 
+          <br /> <b>Connect With Us!</b> <br /> 
           Stay updated on CovEd events, news, and resources on{" "}
           <a href="https://www.facebook.com/CovEducationInc"> Facebook</a>, {" "}
           <a href="https://twitter.com/coveducation"> Twitter</a>,{" "}


### PR DESCRIPTION
The page wasn't being updated because the build step in the build-deploy gh-pages action did not complete correctly. This should fix it and unblock the missing updates to the site from going live.