### PR TITLE
fix: deployment cname

### DIFF
--- a/.github/workflows/contentfulDeploy.yml
+++ b/.github/workflows/contentfulDeploy.yml
@@ -1,9 +1,9 @@
 name: Preview Github Pages
 
 on:
-  push: 
+  push:
     branches: [ main ]
-    
+
   repository_dispatch:
     types: [ contentful.publish ]
 
@@ -16,18 +16,18 @@ jobs:
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.9.1
-      with: 
+      with:
         access_token: ${{ github.token }}
 
     - name: Checkout
       uses: actions/checkout@v2.3.1
-    
+
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.0
       with:
         node-version: 14
         cache: npm
-    
+
     - name: Install Dependencies & Build Website
       #env:
         # CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
       run: |
         npm ci
         npm run build
-    
+
     - name: Deploy 🚀
       uses: crazy-max/ghaction-github-pages@v2.5.0
       env:
@@ -44,4 +44,5 @@ jobs:
       with:
         build_dir: public
         jekyll: false
+        fqdn: coved.org
 


### PR DESCRIPTION
Previously, the GitHub pages action reset the website CNAME. This caused the site to become unreachable after changes have been merged. Adding the `fqdn` field will prevent this from occurring.